### PR TITLE
Fixed "double-dot" extensions in output bin directory

### DIFF
--- a/mapnik.props
+++ b/mapnik.props
@@ -5,23 +5,23 @@
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\mapnik\input\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>mapnik\input\%(FileName).%(Extension)</Link>
+      <Link>mapnik\input\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\mapnik\fonts\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>mapnik\fonts\%(FileName).%(Extension)</Link>
+      <Link>mapnik\fonts\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\gdal\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\gdal\%(FileName).%(Extension)</Link>
+      <Link>share\gdal\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\icu\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\icu\%(FileName).%(Extension)</Link>
+      <Link>share\icu\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\proj\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\proj\%(FileName).%(Extension)</Link>
+      <Link>share\proj\%(FileName)%(Extension)</Link>
     </None>
   </ItemGroup>
 </Project>

--- a/mapnik.x64.props
+++ b/mapnik.x64.props
@@ -5,23 +5,23 @@
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\mapnik\input\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>mapnik\input\%(FileName).%(Extension)</Link>
+      <Link>mapnik\input\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\mapnik\fonts\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>mapnik\fonts\%(FileName).%(Extension)</Link>
+      <Link>mapnik\fonts\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\gdal\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\gdal\%(FileName).%(Extension)</Link>
+      <Link>share\gdal\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\icu\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\icu\%(FileName).%(Extension)</Link>
+      <Link>share\icu\%(FileName)%(Extension)</Link>
     </None>
     <None Include="$(MsBuildThisFileDirectory)\..\..\native\share\proj\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>share\proj\%(FileName).%(Extension)</Link>
+      <Link>share\proj\%(FileName)%(Extension)</Link>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When you install the NuGet package in a project and build, all the Mapnik files will be copied to the output bin directory. However all the files in the `mapnik` and `share` directories will have an extra dot in their names:

![image](https://cloud.githubusercontent.com/assets/1114385/21458525/c9976a40-c8fc-11e6-977b-d6414847a1f1.png)

This change should fix that.

Sorry, I wasn't able to actually test my changes because I don't have .NET 4.5.2 specifically installed on my development machine. But I've done a similar thing for a separate project and I'm pretty sure this should fix the issue.